### PR TITLE
Fix examples/simple.ts for missing logger

### DIFF
--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -9,6 +9,7 @@ interface AppContext {
   multiplier: number;
   logger: {
     log: (message: string) => void;
+    error: (message: string) => void;
   };
 }
 
@@ -17,8 +18,9 @@ const { run, defineTask, getContext } = createContext<AppContext>({
   apiKey: 'demo-key-123',
   multiplier: 2,
   logger: {
-    log: (message: string) => console.log(`[LOG] ${message}`)
-  }
+    log: (message: string) => console.log(`[LOG] ${message}`),
+    error: (message: string) => console.error(`[LOG] ${message}`),
+  },
 });
 
 // === Example 1: Basic Task Definition ===
@@ -127,7 +129,8 @@ async function testingExample() {
   const testResult = await run(greet, 'Test User', {
     overrides: {
       logger: {
-        log: (msg) => console.log(`[TEST] ${msg}`)
+        log: (msg) => console.log(`[TEST] ${msg}`),
+        error: (msg) => console.error(`[TEST] ${msg}`)
       }
     }
   });


### PR DESCRIPTION
I've tried running the example implementation and found some errors

```sh
4. Error handling with Result type:
[LOG] Task succeeded for input: attempt-1
   ✓ Success: Processed: attempt-1
[LOG] Task failed for input: attempt-2
[LOG] [runImpl] Workflow failed: Task failed: Failed to process: attempt-2
   ✗ Error: Task failed: Failed to process: attempt-2
[LOG] Task failed for input: attempt-3
[LOG] [runImpl] Workflow failed: Task failed: Failed to process: attempt-3
   ✗ Error: Task failed: Failed to process: attempt-3
[LOG] Task succeeded for input: attempt-4
   ✓ Success: Processed: attempt-4
[LOG] Task succeeded for input: attempt-5
   ✓ Success: Processed: attempt-5
```